### PR TITLE
Fix string escape bug

### DIFF
--- a/src/js/collab-vm/admin.js
+++ b/src/js/collab-vm/admin.js
@@ -111,7 +111,7 @@ function forEachInput(settings, callback) {
 			} else if ($(this).attr("type") === "number") {
 				value = this.value;
 			} else {
-				value = '"' + this.value + '"';
+				value = JSON.stringify( this.value );
 			}
 			callback(this.name, value);
 		});


### PR DESCRIPTION
This PR fixes the **Root value was not an object** error, by using JSON.stringify.